### PR TITLE
商品詳細機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ### Association
 
 - has_many :items
+- has_many :user_items
 - has_one :item_purchases
 
 ## items テーブル
@@ -35,6 +36,7 @@
 ### Association
 
 - belongs_to :user
+- has_one :user_item
 
 ## item_purchases テーブル
 
@@ -51,6 +53,7 @@
 ### Association
 
 - belongs_to :user
+- belongs_to :user_items
 
 ## user_items テーブル
 
@@ -58,3 +61,7 @@
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
 | item               | references | null: false, foreign_key: true |
+
+- belongs_to :item
+- belongs_to :user
+- has_one :item_purchases

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
+  has_one :user_item
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-         
+
   has_many :items
   has_many :user_items
   has_one :item_purchases

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+         
+  has_many :items
+  has_many :user_items
+  has_one :item_purchases
 
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'Include both letters and numbers' }
 
@@ -18,6 +22,4 @@ class User < ApplicationRecord
       validates :first_name_kana
     end
   end
-  has_many :items
-  has_one :item_purchases
 end

--- a/app/models/user_item.rb
+++ b/app/models/user_item.rb
@@ -1,0 +1,5 @@
+class UserItem < ApplicationRecord
+  belongs_to :item
+  belongs_to :user
+  has_one :item_purchases
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -119,7 +119,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -8,10 +7,10 @@
     </h2>
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%# 商品が売れている場合は、sold outを表示しましょう ※「商品購入機能」実装時作業%>
+      <%# <div class='sold-out'>
         <span>Sold Out!!</span>
-      </div>
+      </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -23,18 +22,15 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user_id && @item.user_item.blank? %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif @item.user_item.blank? %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.info %></span>
@@ -78,7 +74,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -97,7 +97,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price.to_s(:delimited) %>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_burden.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.info %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [ :new, :create, :index ]
+  resources :items, only: [ :new, :create, :index, :show ]
 end

--- a/db/migrate/20201125141037_create_items.rb
+++ b/db/migrate/20201125141037_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer    :prefecture_id,      null: false
       t.integer    :shipping_day_id,    null: false
       t.integer    :price,              null: false
-      t.references :user,         foreign_key: true
+      t.references :user,               null: false , foreign_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20201129122417_create_user_items.rb
+++ b/db/migrate/20201129122417_create_user_items.rb
@@ -1,0 +1,9 @@
+class CreateUserItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_items do |t|
+      t.references :user,         null: false , foreign_key: true
+      t.references :item,         null: false , foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_144420) do
+ActiveRecord::Schema.define(version: 2020_11_29_122417) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema.define(version: 2020_11_25_144420) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "user_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_user_items_on_item_id"
+    t.index ["user_id"], name: "index_user_items_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +77,6 @@ ActiveRecord::Schema.define(version: 2020_11_25_144420) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "user_items", "items"
+  add_foreign_key "user_items", "users"
 end

--- a/spec/factories/user_items.rb
+++ b/spec/factories/user_items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_item do
+    
+  end
+end

--- a/spec/factories/user_items.rb
+++ b/spec/factories/user_items.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :user_item do
-    
   end
 end

--- a/spec/models/user_item_spec.rb
+++ b/spec/models/user_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserItem, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
商品詳細ページ表示機能を作成
・詳細ページ表示
・ログイン状態、ログアウト状態、出品者かどうか、によって表示を変化させる

# Why
商品の詳細ページを表示するため

# 機能実装の様子

 - 商品出品時に登録した情報が見られるようになっている
https://gyazo.com/62dfadf924fcd153cee9ef22c74f60d5
　∟参考：データベース画像  商品テーブルに商品(item_12)が登録されている
　　https://gyazo.com/f1d34d7755d9c4522bd452d19cef6613
### ログイン状態の出品者についての実装

 - 「ログイン状態の出品者」のみ「編集・削除ボタンが表示される」（GyazoGIF）
https://gyazo.com/01e16393d44539aa56ad2127dbaba0ad

 - 「ログイン状態の出品者」でも「売却済みの商品に対しては編集・削除ボタンが表示されない」（GyazoGIF）
https://gyazo.com/78f271d96aed02ee5d303ed020c28e47
　∟参考：データベース画像  桜(item_id:13)は購入情報テーブルから取得できる＝売却済みである
　　https://gyazo.com/ec57e2c2a5cd4ceacd96d381f43d5e6a


### ログイン状態の出品者以外のユーザーについての実装

 - 「ログイン状態の出品者以外のユーザー」のみ「購入画面に進むボタンが表示される」（GyazoGIF）
https://gyazo.com/2db8cf557a62363ddafe580f6bec4c40

 - 「ログイン状態の出品者以外のユーザー」でも「売却済みの商品に対しては、購入画面に進むボタンが表示されない」（GyazoGIF）
https://gyazo.com/02507ebf1c2865e9afa5dfd2597f8af9
　∟参考：データベース画像  桜(item_id:13)は購入情報テーブルから取得できる＝売却済みである
　　https://gyazo.com/ec57e2c2a5cd4ceacd96d381f43d5e6a

### ログアウト状態のユーザーについての実装

 - 「ログアウト状態のユーザー」は「商品詳細表示ページを閲覧できる」が「編集・削除・購入画面に進むボタンは表示されない」（GyazoGIF）
https://gyazo.com/c2f1240b4a934d6bfe703001a50a3720
