### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,22 +38,18 @@ class ItemsController < ApplicationController
   end
 
   private
-  
+
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 
   def move_to_index_soldout
     @item = Item.find(params[:id])
-    unless @item.user_item.blank?
-    redirect_to action: :index
-    end
+    redirect_to action: :index unless @item.user_item.blank?
   end
 
   def move_to_index
     @item = Item.find(params[:id])
-    unless user_signed_in? && current_user.id == @item.user_id
-    redirect_to action: :index
-    end
+    redirect_to action: :index unless user_signed_in? && current_user.id == @item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :move_to_index, only: [:edit]
   before_action :authenticate_user!, only: [:new]
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -26,7 +27,24 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path(@item.id)
+    else
+      render :edit
+    end
+  end
+
+  private
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless user_signed_in? && current_user.id == @item.user_id
+    redirect_to action: :index
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:show, :index]
+  before_action :move_to_index_soldout, only: [:edit]
   before_action :move_to_index, only: [:edit]
-  before_action :authenticate_user!, only: [:new]
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -37,8 +38,16 @@ class ItemsController < ApplicationController
   end
 
   private
+  
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
+  end
+
+  def move_to_index_soldout
+    @item = Item.find(params[:id])
+    unless @item.user_item.blank?
+    redirect_to action: :index
+    end
   end
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,9 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :authenticate_user!, except: [:show, :index]
   before_action :move_to_index_soldout, only: [:edit]
   before_action :move_to_index, only: [:edit]
+  
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -21,15 +23,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
@@ -38,18 +37,26 @@ class ItemsController < ApplicationController
   end
 
   private
-
+  
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :status_id, :shipping_burden_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
   def move_to_index_soldout
     @item = Item.find(params[:id])
-    redirect_to action: :index unless @item.user_item.blank?
+    unless @item.user_item.blank?
+    redirect_to action: :index
+    end
   end
 
   def move_to_index
     @item = Item.find(params[:id])
-    redirect_to action: :index unless user_signed_in? && current_user.id == @item.user_id
+    unless user_signed_in? && current_user.id == @item.user_id
+    redirect_to action: :index
+    end
   end
 end

--- a/app/models/user_item.rb
+++ b/app/models/user_item.rb
@@ -1,5 +1,5 @@
-class UserItem < ApplicationRecord
-  belongs_to :item
-  belongs_to :user
-  has_one :item_purchases
-end
+# class UserItem < ApplicationRecord
+#   belongs_to :item
+#   belongs_to :user
+#   has_one :item_purchases
+# end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,13 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
-    <%# 出品画像 %>
+    <%= form_with(model: @item , url: item_path, local: true) do |f| %>
+    
+    <%= render 'shared/error_messages', model: f.object %>
+    
     <div class="img-upload">
       <div class="weight-bold-text">
         出品画像
@@ -23,28 +20,24 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /出品画像 %>
-    <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
 
-    <%# 商品の詳細 %>
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -52,17 +45,15 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
 
-    <%# 配送について %>
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -73,22 +64,20 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_burden_id, ShippingBurden.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
 
-    <%# 販売価格 %>
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -101,7 +90,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +130,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
@@ -106,9 +103,6 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -126,13 +120,10 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
       <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id && @item.user_item.blank? %>
-        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% elsif @item.user_item.blank? %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id && @item.user_item.blank? %>
-        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
       <% elsif @item.user_item.blank? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [ :new, :create, :index, :show ]
+  resources :items, only: [ :new, :create, :index, :show, :edit, :update ]
 end

--- a/db/migrate/20201129122417_create_user_items.rb
+++ b/db/migrate/20201129122417_create_user_items.rb
@@ -1,9 +1,9 @@
-class CreateUserItems < ActiveRecord::Migration[6.0]
-  def change
-    create_table :user_items do |t|
-      t.references :user,         null: false , foreign_key: true
-      t.references :item,         null: false , foreign_key: true
-      t.timestamps
-    end
-  end
-end
+# class CreateUserItems < ActiveRecord::Migration[6.0]
+#   def change
+#     create_table :user_items do |t|
+#       t.references :user,         null: false , foreign_key: true
+#       t.references :item,         null: false , foreign_key: true
+#       t.timestamps
+#     end
+#   end
+# end


### PR DESCRIPTION
# What
商品情報編集機能を作成

# Why
商品の情報を編集するため

# 機能実装の様子

 - 必要な情報を適切に入力すると、商品情報を変更できる（GyazoGIF）
　・商品出品時とほぼ同じ見た目で商品情報編集機能が実装されている
　・すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される
https://gyazo.com/7cc74101cede520a67aa94de493d0e67

 - 「ログイン状態の出品者だけ」が「商品情報編集ページに遷移できる」（GyazoGIF）
https://gyazo.com/051eef76ca020328987d0edd62d35f82

 - 「ログイン状態の出品者以外のユーザー」が
　「直接、商品の商品情報編集ページへ遷移しようとする」→トップページに遷移（GyazoGIF）
https://gyazo.com/02b58cc24d384994ebc1036f1660a108

 - 「ログアウト状態のユーザー」が
　「直接、商品情報編集ページへ遷移しようとする」→ログインページに遷移（GyazoGIF）
https://gyazo.com/2a6c04689d6bbaed5b0b5287fe6f82a2

 - 「出品者・出品者以外にかかわらず、ログイン状態のユーザー」が
　「直接、売却済み商品の商品情報編集ページへ遷移しようとする」→トップページに遷移（GyazoGIF）
https://gyazo.com/6670e2aef5b6dfdef4daf9bef467eff1

 - 「ログアウト状態のユーザー」が
　「直接、売却済み商品の商品情報編集ページへ遷移しようとする」→ログインページに遷移（GyazoGIF）
https://gyazo.com/bc574bfdf582bfcd2868faf98b2488b5

 - エラーメッセージの出力は、商品情報編集ページにて行うこと
https://gyazo.com/7eaf13c81fc9fa21e34fe12395087f65